### PR TITLE
Semantic fixes

### DIFF
--- a/contextualized/regression/lightning_modules.py
+++ b/contextualized/regression/lightning_modules.py
@@ -126,7 +126,7 @@ class NaiveContextualizedRegression(ContextualizedRegressionBase):
         for (beta_hats, mu_hats), data in zip(preds, dataloader):
             _, X, _, n_idx = data
             for beta_hat, mu_hat, x, n_i in zip(beta_hats, mu_hats, X, n_idx):
-                ys[n_i] = self.link_fn((beta_hat * x).sum(axis=-1).unsqueeze(-1) + mu_hat).squeeze(-1)
+                ys[n_i] = self._predict_from_models(x, beta_hat, mu_hat).squeeze(-1)
         return ys
 
     def dataloader(self, C, X, Y, batch_size=32):
@@ -170,7 +170,7 @@ class ContextualizedRegression(ContextualizedRegressionBase):
         for (beta_hats, mu_hats), data in zip(preds, dataloader):
             _, X, _, n_idx = data
             for beta_hat, mu_hat, x, n_i in zip(beta_hats, mu_hats, X, n_idx):
-                ys[n_i] = self.link_fn((beta_hat * x).sum(axis=-1).unsqueeze(-1) + mu_hat).squeeze(-1)
+                ys[n_i] = self._predict_from_models(x, beta_hat, mu_hat).squeeze(-1)
         return ys
 
     def dataloader(self, C, X, Y, batch_size=32):
@@ -214,7 +214,7 @@ class MultitaskContextualizedRegression(ContextualizedRegressionBase):
         for (beta_hats, mu_hats), data in zip(preds, dataloader):
             _, _, X, _, n_idx, y_idx = data
             for beta_hat, mu_hat, x, n_i, y_i in zip(beta_hats, mu_hats, X, n_idx, y_idx):
-                ys[n_i, y_i] = self.link_fn((beta_hat * x).sum(axis=-1).unsqueeze(-1) + mu_hat).squeeze()
+                ys[n_i, y_i] = self._predict_from_models(x, beta_hat, mu_hat).squeeze()
         return ys
 
     def dataloader(self, C, X, Y, batch_size=32):
@@ -258,7 +258,7 @@ class TasksplitContextualizedRegression(ContextualizedRegressionBase):
         for (beta_hats, mu_hats), data in zip(preds, dataloader):
             _, _, X, _, n_idx, y_idx = data
             for beta_hat, mu_hat, x, n_i, y_i in zip(beta_hats, mu_hats, X, n_idx, y_idx):
-                ys[n_i, y_i] = self.link_fn((beta_hat * x).sum(axis=-1).unsqueeze(-1) + mu_hat).squeeze()
+                ys[n_i, y_i] = self._predict_from_models(x, beta_hat, mu_hat).squeeze()
         return ys
 
     def dataloader(self, C, X, Y, batch_size=32):
@@ -290,7 +290,7 @@ class ContextualizedUnivariateRegression(ContextualizedRegression):
         for (beta_hats, mu_hats), data in zip(preds, dataloader):
             _, X, _, n_idx = data
             for beta_hat, mu_hat, x, n_i in zip(beta_hats, mu_hats, X, n_idx):
-                ys[n_i] = self.link_fn((beta_hat * x).sum(axis=-1).unsqueeze(-1) + mu_hat).squeeze(-1)
+                ys[n_i] = self._predict_from_models(x, beta_hat, mu_hat).squeeze(-1)
         return ys
 
     def dataloader(self, C, X, Y, batch_size=32):
@@ -334,7 +334,7 @@ class TasksplitContextualizedUnivariateRegression(ContextualizedRegressionBase):
         for (beta_hats, mu_hats), data in zip(preds, dataloader):
             _, _, X, _, n_idx, x_idx, y_idx = data
             for beta_hat, mu_hat, x, n_i, x_i, y_i in zip(beta_hats, mu_hats, X, n_idx, x_idx, y_idx):
-                ys[n_i, y_i, x_i] = self.link_fn(beta_hat * x + mu_hat).squeeze()
+                ys[n_i, y_i, x_i] = self._predict_from_models(x, beta_hat, mu_hat).squeeze()
         return ys
 
     def dataloader(self, C, X, Y, batch_size=32):

--- a/contextualized/regression/lightning_modules.py
+++ b/contextualized/regression/lightning_modules.py
@@ -24,9 +24,8 @@ from contextualized.regression.datasets import DataIterable, MultivariateDataset
 
 
 class ContextualizedRegressionBase(pl.LightningModule):
-    def __init__(self, learning_rate=1e-3, link_fn=LINK_FUNCTIONS['identity'],
-                 loss_fn=LOSSES['mse'], model_regularizer=REGULARIZERS['none'],
-                 *args, **kwargs):
+    def __init__(self, *args, learning_rate=1e-3, link_fn=LINK_FUNCTIONS['identity'],
+                 loss_fn=LOSSES['mse'], model_regularizer=REGULARIZERS['none'], **kwargs):
         super().__init__()
         self.learning_rate = learning_rate
         self.link_fn = link_fn

--- a/contextualized/regression/tests.py
+++ b/contextualized/regression/tests.py
@@ -59,43 +59,43 @@ if __name__ == '__main__':
         print()
 
     # Naive Multivariate
-    model = NaiveContextualizedRegression(context_dim=c_dim, x_dim=x_dim, y_dim=y_dim,
+    model = NaiveContextualizedRegression(c_dim, x_dim, y_dim,
         encoder_kwargs={'width': 25, 'layers': 2, 'link_fn': LINK_FUNCTIONS['identity']},
         link_fn=LINK_FUNCTIONS['identity'])
     quicktest(model)
 
-    model = NaiveContextualizedRegression(context_dim=c_dim, x_dim=x_dim, y_dim=y_dim,
+    model = NaiveContextualizedRegression(c_dim, x_dim, y_dim,
         encoder_kwargs={'width': 25, 'layers': 2, 'link_fn': LINK_FUNCTIONS['softmax']},
         link_fn=LINK_FUNCTIONS['identity'])
     quicktest(model)
 
     # Naive Multivariate
-    model = NaiveContextualizedRegression(context_dim=c_dim, x_dim=x_dim, y_dim=y_dim,
+    model = NaiveContextualizedRegression(c_dim, x_dim, y_dim,
         encoder_kwargs={'width': 25, 'layers': 2, 'link_fn': LINK_FUNCTIONS['identity']},
         link_fn=LINK_FUNCTIONS['softmax'])
     quicktest(model)
 
-    model = NaiveContextualizedRegression(context_dim=c_dim, x_dim=x_dim, y_dim=y_dim,
+    model = NaiveContextualizedRegression(c_dim, x_dim, y_dim,
         encoder_kwargs={'width': 25, 'layers': 2, 'link_fn': LINK_FUNCTIONS['softmax']},
         link_fn=LINK_FUNCTIONS['softmax'])
     quicktest(model)
 
     # Subtype Multivariate
-    model = ContextualizedRegression(context_dim=c_dim, x_dim=x_dim, y_dim=y_dim)
+    model = ContextualizedRegression(c_dim, x_dim, y_dim)
     quicktest(model)
 
     # Multitask Multivariate
-    model = MultitaskContextualizedRegression(context_dim=c_dim, x_dim=x_dim, y_dim=y_dim)
+    model = MultitaskContextualizedRegression(c_dim, x_dim, y_dim)
     quicktest(model)
 
     # Tasksplit Multivariate
-    model = TasksplitContextualizedRegression(context_dim=c_dim, x_dim=x_dim, y_dim=y_dim)
+    model = TasksplitContextualizedRegression(c_dim, x_dim, y_dim)
     quicktest(model)
 
     # Univariate
-    model = ContextualizedUnivariateRegression(context_dim=c_dim, x_dim=x_dim, y_dim=y_dim)
+    model = ContextualizedUnivariateRegression(c_dim, x_dim, y_dim)
     quicktest(model)
 
     # Tasksplit Univariate
-    model = TasksplitContextualizedUnivariateRegression(context_dim=c_dim, x_dim=x_dim, y_dim=y_dim)
+    model = TasksplitContextualizedUnivariateRegression(c_dim, x_dim, y_dim)
     quicktest(model)


### PR DESCRIPTION
- Replaced duplicated code in `regression.lightning_modules._y_reshape` with `regression.lightning_modules._predict_from_models`
- Made `context_dim` ,`x_dim`, and `y_dim` mandatory args for regression lightning modules