### PR TITLE
Convergence tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 experiments/*
+*/lightning_logs/*
 __pycache__
 nb_archive
 sergio_temp

--- a/contextualized/functions.py
+++ b/contextualized/functions.py
@@ -27,7 +27,7 @@ def identity_link_constructor():
     return make_fn(identity_link)
 
 
-def linear_link_constructor(m=0, b=0):
+def linear_link_constructor(m=1, b=0):
     return make_fn(linear_link, m=m, b=b)
 
 

--- a/contextualized/regression/__init__.py
+++ b/contextualized/regression/__init__.py
@@ -7,6 +7,7 @@ ENCODERS = {
 from contextualized.functions import *
 LINK_FUNCTIONS = {
     'identity': linear_link_constructor(),
+    'logistic': logistic_constructor(),
     'softmax': softmax_link_constructor()
 }
 

--- a/contextualized/regression/lightning_modules.py
+++ b/contextualized/regression/lightning_modules.py
@@ -88,6 +88,11 @@ class ContextualizedRegressionBase(pl.LightningModule):
     def _predict_from_models(self, X, beta_hat, mu_hat):
         return self.link_fn((beta_hat * X).sum(axis=-1).unsqueeze(-1) + mu_hat)
 
+    def _dataloader(self, C, X, Y, dataset_constructor, **kwargs):
+        kwargs['num_workers'] = kwargs.get('num_workers', 0)
+        kwargs['batch_size'] = kwargs.get('batch_size', 32)
+        return DataLoader(dataset=DataIterable(dataset_constructor(C, X, Y)), **kwargs)
+
 
 class NaiveContextualizedRegression(ContextualizedRegressionBase):
     """
@@ -129,8 +134,8 @@ class NaiveContextualizedRegression(ContextualizedRegressionBase):
                 ys[n_i] = self._predict_from_models(x, beta_hat, mu_hat).squeeze(-1)
         return ys
 
-    def dataloader(self, C, X, Y, batch_size=32):
-        return DataLoader(dataset=DataIterable(MultivariateDataset(C, X, Y)), batch_size=batch_size)
+    def dataloader(self, C, X, Y, **kwargs):
+        return self._dataloader(C, X, Y, MultivariateDataset, **kwargs)
 
 
 class ContextualizedRegression(ContextualizedRegressionBase):
@@ -173,8 +178,8 @@ class ContextualizedRegression(ContextualizedRegressionBase):
                 ys[n_i] = self._predict_from_models(x, beta_hat, mu_hat).squeeze(-1)
         return ys
 
-    def dataloader(self, C, X, Y, batch_size=32):
-        return DataLoader(dataset=DataIterable(MultivariateDataset(C, X, Y)), batch_size=batch_size)
+    def dataloader(self, C, X, Y, **kwargs):
+        return self._dataloader(C, X, Y, MultivariateDataset, **kwargs)
 
 
 class MultitaskContextualizedRegression(ContextualizedRegressionBase):
@@ -217,8 +222,8 @@ class MultitaskContextualizedRegression(ContextualizedRegressionBase):
                 ys[n_i, y_i] = self._predict_from_models(x, beta_hat, mu_hat).squeeze()
         return ys
 
-    def dataloader(self, C, X, Y, batch_size=32):
-        return DataLoader(dataset=DataIterable(MultitaskMultivariateDataset(C, X, Y)), batch_size=batch_size)
+    def dataloader(self, C, X, Y, **kwargs):
+        return self._dataloader(C, X, Y, MultitaskMultivariateDataset, **kwargs)
 
 
 class TasksplitContextualizedRegression(ContextualizedRegressionBase):
@@ -261,8 +266,8 @@ class TasksplitContextualizedRegression(ContextualizedRegressionBase):
                 ys[n_i, y_i] = self._predict_from_models(x, beta_hat, mu_hat).squeeze()
         return ys
 
-    def dataloader(self, C, X, Y, batch_size=32):
-        return DataLoader(dataset=DataIterable(MultitaskMultivariateDataset(C, X, Y)), batch_size=batch_size)
+    def dataloader(self, C, X, Y, **kwargs):
+        return self._dataloader(C, X, Y, MultitaskMultivariateDataset, **kwargs)
 
 
 class ContextualizedUnivariateRegression(ContextualizedRegression):
@@ -293,8 +298,8 @@ class ContextualizedUnivariateRegression(ContextualizedRegression):
                 ys[n_i] = self._predict_from_models(x, beta_hat, mu_hat).squeeze(-1)
         return ys
 
-    def dataloader(self, C, X, Y, batch_size=32):
-        return DataLoader(dataset=DataIterable(UnivariateDataset(C, X, Y)), batch_size=batch_size)
+    def dataloader(self, C, X, Y, **kwargs):
+        return self._dataloader(C, X, Y, UnivariateDataset, **kwargs)
 
 
 class TasksplitContextualizedUnivariateRegression(ContextualizedRegressionBase):
@@ -337,5 +342,5 @@ class TasksplitContextualizedUnivariateRegression(ContextualizedRegressionBase):
                 ys[n_i, y_i, x_i] = self._predict_from_models(x, beta_hat, mu_hat).squeeze()
         return ys
 
-    def dataloader(self, C, X, Y, batch_size=32):
-        return DataLoader(dataset=DataIterable(MultitaskUnivariateDataset(C, X, Y)), batch_size=batch_size)
+    def dataloader(self, C, X, Y, **kwargs):
+        return self._dataloader(C, X, Y, MultitaskUnivariateDataset, **kwargs)

--- a/contextualized/regression/tests.py
+++ b/contextualized/regression/tests.py
@@ -23,7 +23,6 @@ from contextualized.regression.lightning_modules import *
 from contextualized.regression.trainers import RegressionTrainer
 from contextualized.regression import ENCODERS, LINK_FUNCTIONS
 
-
 if __name__ == '__main__':
     n = 100
     c_dim = 4
@@ -51,11 +50,15 @@ if __name__ == '__main__':
         print(f'{type(model)} quicktest')
         dataloader = model.dataloader(C, X, Y, batch_size=32)
         trainer = RegressionTrainer(max_epochs=1)
+        y_preds = trainer.predict_y(model, dataloader)
+        err_init = np.linalg.norm(Y - y_preds, ord=2)
         trainer.fit(model, dataloader)
         trainer.validate(model, dataloader)
         trainer.test(model, dataloader)
         beta_preds, mu_preds = trainer.predict_params(model, dataloader)
         y_preds = trainer.predict_y(model, dataloader)
+        err_trained = np.linalg.norm(Y - y_preds, ord=2)
+        assert err_trained < err_init
         print()
 
     # Naive Multivariate
@@ -69,15 +72,14 @@ if __name__ == '__main__':
         link_fn=LINK_FUNCTIONS['identity'])
     quicktest(model)
 
-    # Naive Multivariate
     model = NaiveContextualizedRegression(c_dim, x_dim, y_dim,
         encoder_kwargs={'width': 25, 'layers': 2, 'link_fn': LINK_FUNCTIONS['identity']},
-        link_fn=LINK_FUNCTIONS['softmax'])
+        link_fn=LINK_FUNCTIONS['logistic'])
     quicktest(model)
 
     model = NaiveContextualizedRegression(c_dim, x_dim, y_dim,
         encoder_kwargs={'width': 25, 'layers': 2, 'link_fn': LINK_FUNCTIONS['softmax']},
-        link_fn=LINK_FUNCTIONS['softmax'])
+        link_fn=LINK_FUNCTIONS['logistic']())
     quicktest(model)
 
     # Subtype Multivariate
@@ -92,6 +94,7 @@ if __name__ == '__main__':
     model = TasksplitContextualizedRegression(c_dim, x_dim, y_dim)
     quicktest(model)
 
+    """
     # Univariate
     model = ContextualizedUnivariateRegression(c_dim, x_dim, y_dim)
     quicktest(model)
@@ -99,3 +102,4 @@ if __name__ == '__main__':
     # Tasksplit Univariate
     model = TasksplitContextualizedUnivariateRegression(c_dim, x_dim, y_dim)
     quicktest(model)
+    """


### PR DESCRIPTION
Add tests for model convergence (it must be more accurate after 1 epoch of training than at initialization) to regression quicktests.

Univariate models are failing currently due to predict_y shapes.