### PR TITLE
add base predictor option to regression and easy modules #89

### DIFF
--- a/contextualized/easy/tests/test_regressor.py
+++ b/contextualized/easy/tests/test_regressor.py
@@ -4,7 +4,7 @@ import torch
 from contextualized.easy import ContextualizedClassifier, ContextualizedRegressor
 
 
-class DummyBasePredictor:
+class DummyParamPredictor:
     def __init__(self, beta_dim, mu_dim):
         self.beta_dim = beta_dim
         self.mu_dim = mu_dim
@@ -12,6 +12,15 @@ class DummyBasePredictor:
     def predict_params(self, *args):
         n = len(args[0])
         return torch.zeros((n, *self.beta_dim)), torch.zeros((n, *self.mu_dim))
+
+
+class DummyYPredictor:
+    def __init__(self, y_dim):
+        self.y_dim = y_dim
+
+    def predict_y(self, *args):
+        n = len(args[0])
+        return torch.zeros((n, *self.y_dim))
 
 
 def quicktest(model, C, X, Y, **kwargs):
@@ -53,8 +62,9 @@ def test_regressor():
     C, X, Y = C.numpy(), X.numpy(), Y.numpy()
 
     # Naive Multivariate
-    dummybase = DummyBasePredictor((y_dim, x_dim), (y_dim, 1))
-    model = ContextualizedRegressor(base_predictor=dummybase)
+    parambase = DummyParamPredictor((y_dim, x_dim), (y_dim, 1))
+    ybase = DummyYPredictor((y_dim, 1))
+    model = ContextualizedRegressor(base_param_predictor=parambase, base_y_predictor=ybase)
     quicktest(model, C, X, Y, max_epochs=1)
 
     model = ContextualizedRegressor(num_archetypes=0)
@@ -70,7 +80,7 @@ def test_regressor():
 
     # With bootstrap
     model = ContextualizedRegressor(num_archetypes=4, alpha=0.1,
-        l1_ratio=0.5, mu_ratio=0.9, base_predictor=dummybase)
+        l1_ratio=0.5, mu_ratio=0.9, base_param_predictor=parambase, base_y_predictor=ybase)
     quicktest(model, C, X, Y, max_epochs=1, n_bootstraps=2,
         learning_rate=1e-3)
 

--- a/contextualized/easy/tests/test_regressor.py
+++ b/contextualized/easy/tests/test_regressor.py
@@ -4,6 +4,16 @@ import torch
 from contextualized.easy import ContextualizedClassifier, ContextualizedRegressor
 
 
+class DummyBasePredictor:
+    def __init__(self, beta_dim, mu_dim):
+        self.beta_dim = beta_dim
+        self.mu_dim = mu_dim
+
+    def predict_params(self, *args):
+        n = len(args[0])
+        return torch.zeros((n, *self.beta_dim)), torch.zeros((n, *self.mu_dim))
+
+
 def quicktest(model, C, X, Y, **kwargs):
     print(f'{type(model)} quicktest')
     model.fit(C, X, Y, max_epochs=0)
@@ -43,7 +53,8 @@ def test_regressor():
     C, X, Y = C.numpy(), X.numpy(), Y.numpy()
 
     # Naive Multivariate
-    model = ContextualizedRegressor()
+    dummybase = DummyBasePredictor((y_dim, x_dim), (y_dim, 1))
+    model = ContextualizedRegressor(base_predictor=dummybase)
     quicktest(model, C, X, Y, max_epochs=1)
 
     model = ContextualizedRegressor(num_archetypes=0)
@@ -59,7 +70,7 @@ def test_regressor():
 
     # With bootstrap
     model = ContextualizedRegressor(num_archetypes=4, alpha=0.1,
-        l1_ratio=0.5, mu_ratio=0.9)
+        l1_ratio=0.5, mu_ratio=0.9, base_predictor=dummybase)
     quicktest(model, C, X, Y, max_epochs=1, n_bootstraps=2,
         learning_rate=1e-3)
 

--- a/contextualized/easy/wrappers.py
+++ b/contextualized/easy/wrappers.py
@@ -18,7 +18,7 @@ class SKLearnInterface():
         acceptable_model_kwargs = [
             'loss_fn', 'link_fn', 'univariate', 'encoder_type',
             'encoder_kwargs', 'model_regularizer', 'num_archetypes',
-            'learning_rate'
+            'learning_rate', 'base_predictor'
         ]
         acceptable_trainer_kwargs = [
             'max_epochs', 'check_val_every_n_epoch', 'val_check_interval',

--- a/contextualized/easy/wrappers.py
+++ b/contextualized/easy/wrappers.py
@@ -18,7 +18,7 @@ class SKLearnInterface():
         acceptable_model_kwargs = [
             'loss_fn', 'link_fn', 'univariate', 'encoder_type',
             'encoder_kwargs', 'model_regularizer', 'num_archetypes',
-            'learning_rate', 'base_predictor'
+            'learning_rate', 'base_param_predictor', 'base_y_predictor'
         ]
         acceptable_trainer_kwargs = [
             'max_epochs', 'check_val_every_n_epoch', 'val_check_interval',

--- a/contextualized/regression/lightning_modules.py
+++ b/contextualized/regression/lightning_modules.py
@@ -26,13 +26,15 @@ from contextualized.regression.datasets import DataIterable, MultivariateDataset
 class ContextualizedRegressionBase(pl.LightningModule):
     def __init__(self, *args, learning_rate=1e-3, link_fn=LINK_FUNCTIONS['identity'],
                  loss_fn=LOSSES['mse'], model_regularizer=REGULARIZERS['none'], 
-                 base_predictor=None, **kwargs):
+                 base_y_predictor=None, base_param_predictor=None, 
+                 **kwargs):
         super().__init__()
         self.learning_rate = learning_rate
         self.link_fn = link_fn
         self.loss_fn = loss_fn
         self.model_regularizer = model_regularizer
-        self.base_predictor = base_predictor
+        self.base_y_predictor = base_y_predictor
+        self.base_param_predictor = base_param_predictor
         self._build_metamodel(*args, **kwargs)
 
     @abstractmethod
@@ -67,8 +69,8 @@ class ContextualizedRegressionBase(pl.LightningModule):
 
     def forward(self, *args):
         beta, mu = self.metamodel(*args)
-        if self.base_predictor is not None:
-            base_beta, base_mu = self.base_predictor.predict_params(*args)
+        if self.base_param_predictor is not None:
+            base_beta, base_mu = self.base_param_predictor.predict_params(*args)
             beta = beta + base_beta
             mu = mu + base_mu
         return beta, mu
@@ -95,6 +97,12 @@ class ContextualizedRegressionBase(pl.LightningModule):
     def _predict_from_models(self, X, beta_hat, mu_hat):
         return self.link_fn((beta_hat * X).sum(axis=-1).unsqueeze(-1) + mu_hat)
 
+    def _predict_y(self, C, X, beta_hat, mu_hat):
+        Y = self._predict_from_models(X, beta_hat, mu_hat)
+        if self.base_y_predictor is not None:
+            Y = Y + self.base_y_predictor.predict_y(C, X)
+        return Y
+    
     def _dataloader(self, C, X, Y, dataset_constructor, **kwargs):
         kwargs['num_workers'] = kwargs.get('num_workers', 0)
         kwargs['batch_size'] = kwargs.get('batch_size', 32)
@@ -112,7 +120,7 @@ class NaiveContextualizedRegression(ContextualizedRegressionBase):
     def _batch_loss(self, batch, batch_idx):
         C, X, Y, _ = batch
         beta_hat, mu_hat = self(C)
-        pred_loss = self.loss_fn(Y, self._predict_from_models(X, beta_hat, mu_hat))
+        pred_loss = self.loss_fn(Y, self._predict_y(C, X, beta_hat, mu_hat))
         reg_loss  = self.model_regularizer(beta_hat, mu_hat)
         return pred_loss + reg_loss
 
@@ -135,8 +143,8 @@ class NaiveContextualizedRegression(ContextualizedRegressionBase):
         ds = dataloader.dataset.dataset
         ys = np.zeros((ds.n, ds.y_dim))
         for (beta_hats, mu_hats), data in zip(preds, dataloader):
-            _, X, _, n_idx = data
-            ys[n_idx] = self._predict_from_models(X, beta_hats, mu_hats).squeeze(-1)
+            C, X, _, n_idx = data
+            ys[n_idx] = self._predict_y(C, X, beta_hats, mu_hats).squeeze(-1)
         return ys
 
     def dataloader(self, C, X, Y, **kwargs):
@@ -154,7 +162,7 @@ class ContextualizedRegression(ContextualizedRegressionBase):
     def _batch_loss(self, batch, batch_idx):
         C, X, Y, _, = batch
         beta_hat, mu_hat = self(C)
-        pred_loss = self.loss_fn(Y, self._predict_from_models(X, beta_hat, mu_hat))
+        pred_loss = self.loss_fn(Y, self._predict_y(C, X, beta_hat, mu_hat))
         reg_loss  = self.model_regularizer(beta_hat, mu_hat)
         return pred_loss + reg_loss
 
@@ -177,8 +185,8 @@ class ContextualizedRegression(ContextualizedRegressionBase):
         ds = dataloader.dataset.dataset
         ys = np.zeros((ds.n, ds.y_dim))
         for (beta_hats, mu_hats), data in zip(preds, dataloader):
-            _, X, _, n_idx = data
-            ys[n_idx] = self._predict_from_models(X, beta_hats, mu_hats).squeeze(-1)
+            C, X, _, n_idx = data
+            ys[n_idx] = self._predict_y(C, X, beta_hats, mu_hats).squeeze(-1)
         return ys
 
     def dataloader(self, C, X, Y, **kwargs):
@@ -196,7 +204,7 @@ class MultitaskContextualizedRegression(ContextualizedRegressionBase):
     def _batch_loss(self, batch, batch_idx):
         C, T, X, Y, _, _ = batch
         beta_hat, mu_hat = self(C, T)
-        pred_loss = self.loss_fn(Y, self._predict_from_models(X, beta_hat, mu_hat))
+        pred_loss = self.loss_fn(Y, self._predict_y(C, X, beta_hat, mu_hat))
         reg_loss  = self.model_regularizer(beta_hat, mu_hat)
         return pred_loss + reg_loss
 
@@ -219,8 +227,8 @@ class MultitaskContextualizedRegression(ContextualizedRegressionBase):
         ds = dataloader.dataset.dataset
         ys = np.zeros((ds.n, ds.y_dim))
         for (beta_hats, mu_hats), data in zip(preds, dataloader):
-            _, _, X, _, n_idx, y_idx = data
-            ys[n_idx, y_idx] = self._predict_from_models(X, beta_hats, mu_hats).squeeze(-1)
+            C, _, X, _, n_idx, y_idx = data
+            ys[n_idx, y_idx] = self._predict_y(C, X, beta_hats, mu_hats).squeeze(-1)
         return ys
 
     def dataloader(self, C, X, Y, **kwargs):
@@ -238,7 +246,7 @@ class TasksplitContextualizedRegression(ContextualizedRegressionBase):
     def _batch_loss(self, batch, batch_idx):
         C, T, X, Y, _, _ = batch
         beta_hat, mu_hat = self(C, T)
-        pred_loss = self.loss_fn(Y, self._predict_from_models(X, beta_hat, mu_hat))
+        pred_loss = self.loss_fn(Y, self._predict_y(C, X, beta_hat, mu_hat))
         reg_loss  = self.model_regularizer(beta_hat, mu_hat)
         return pred_loss + reg_loss
 
@@ -261,8 +269,8 @@ class TasksplitContextualizedRegression(ContextualizedRegressionBase):
         ds = dataloader.dataset.dataset
         ys = np.zeros((ds.n, ds.y_dim))
         for (beta_hats, mu_hats), data in zip(preds, dataloader):
-            _, _, X, _, n_idx, y_idx = data
-            ys[n_idx, y_idx] = self._predict_from_models(X, beta_hats, mu_hats).squeeze(-1)
+            C, _, X, _, n_idx, y_idx = data
+            ys[n_idx, y_idx] = self._predict_y(C, X, beta_hats, mu_hats).squeeze(-1)
         return ys
 
     def dataloader(self, C, X, Y, **kwargs):
@@ -291,8 +299,8 @@ class ContextualizedUnivariateRegression(ContextualizedRegression):
         ds = dataloader.dataset.dataset
         ys = np.zeros((ds.n, ds.y_dim, ds.x_dim))
         for (beta_hats, mu_hats), data in zip(preds, dataloader):
-            _, X, _, n_idx = data
-            ys[n_idx] = self._predict_from_models(X, beta_hats, mu_hats).squeeze(-1)
+            C, X, _, n_idx = data
+            ys[n_idx] = self._predict_y(C, X, beta_hats, mu_hats).squeeze(-1)
         return ys
 
     def dataloader(self, C, X, Y, **kwargs):
@@ -310,7 +318,7 @@ class TasksplitContextualizedUnivariateRegression(ContextualizedRegressionBase):
     def _batch_loss(self, batch, batch_idx):
         C, T, X, Y, _, _, _ = batch
         beta_hat, mu_hat = self.metamodel(C, T)
-        pred_loss = self.loss_fn(Y, self._predict_from_models(X, beta_hat, mu_hat))
+        pred_loss = self.loss_fn(Y, self._predict_y(C, X, beta_hat, mu_hat))
         reg_loss  = self.model_regularizer(beta_hat, mu_hat)
         return pred_loss + reg_loss
 
@@ -333,8 +341,8 @@ class TasksplitContextualizedUnivariateRegression(ContextualizedRegressionBase):
         ds = dataloader.dataset.dataset
         ys = np.zeros((ds.n, ds.y_dim, ds.x_dim))
         for (beta_hats, mu_hats), data in zip(preds, dataloader):
-            _, _, X, _, n_idx, x_idx, y_idx = data
-            ys[n_idx, y_idx, x_idx] = self._predict_from_models(X, beta_hats, mu_hats).squeeze(-1)
+            C, _, X, _, n_idx, x_idx, y_idx = data
+            ys[n_idx, y_idx, x_idx] = self._predict_y(C, X, beta_hats, mu_hats).squeeze(-1)
         return ys
 
     def dataloader(self, C, X, Y, **kwargs):

--- a/contextualized/regression/tests.py
+++ b/contextualized/regression/tests.py
@@ -120,43 +120,50 @@ class TestRegression(unittest.TestCase):
     def test_subtype(self):
         # Subtype Multivariate
         parambase = DummyParamPredictor((self.y_dim, self.x_dim), (self.y_dim, 1))
-        model = ContextualizedRegression(self.c_dim, self.x_dim, self.y_dim, base_param_predictor=parambase)
+        ybase = DummyYPredictor((self.y_dim, 1))
+        model = ContextualizedRegression(self.c_dim, self.x_dim, self.y_dim, base_param_predictor=parambase, base_y_predictor=ybase)
         self._quicktest(model)
 
     def test_multitask(self):
         # Multitask Multivariate
         parambase = DummyParamPredictor((self.x_dim,), (1,))
-        model = MultitaskContextualizedRegression(self.c_dim, self.x_dim, self.y_dim, base_param_predictor=parambase)
+        ybase = DummyYPredictor((1,))
+        model = MultitaskContextualizedRegression(self.c_dim, self.x_dim, self.y_dim, base_param_predictor=parambase, base_y_predictor=ybase)
         self._quicktest(model)
 
     def test_tasksplit(self):
         # Tasksplit Multivariate
         parambase = DummyParamPredictor((self.x_dim,), (1,))
-        model = TasksplitContextualizedRegression(self.c_dim, self.x_dim, self.y_dim, base_param_predictor=parambase)
+        ybase = DummyYPredictor((1,))
+        model = TasksplitContextualizedRegression(self.c_dim, self.x_dim, self.y_dim, base_param_predictor=parambase, base_y_predictor=ybase)
         self._quicktest(model)
 
     def test_univariate_subtype(self):
         # Naive Univariate
         parambase = DummyParamPredictor((self.y_dim, self.x_dim, 1), (self.y_dim, self.x_dim, 1))
-        model = ContextualizedUnivariateRegression(self.c_dim, self.x_dim, self.y_dim, base_param_predictor=parambase)
+        ybase = DummyYPredictor((self.y_dim, self.x_dim, 1))
+        model = ContextualizedUnivariateRegression(self.c_dim, self.x_dim, self.y_dim, base_param_predictor=parambase, base_y_predictor=ybase)
         self._quicktest(model, univariate=True)
 
     def test_univariate_tasksplit(self):
         # Tasksplit Univariate
         parambase = DummyParamPredictor((1,), (1,))
-        model = TasksplitContextualizedUnivariateRegression(self.c_dim, self.x_dim, self.y_dim, base_param_predictor=parambase)
+        ybase = DummyYPredictor((1,))
+        model = TasksplitContextualizedUnivariateRegression(self.c_dim, self.x_dim, self.y_dim, base_param_predictor=parambase, base_y_predictor=ybase)
         self._quicktest(model, univariate=True)
 
     def test_correlation_subtype(self):
         # Correlation
         parambase = DummyParamPredictor((self.x_dim, self.x_dim, 1), (self.x_dim, self.x_dim, 1))
-        model = ContextualizedCorrelation(self.c_dim, self.x_dim, base_param_predictor=parambase)
+        ybase = DummyYPredictor((self.x_dim, self.x_dim, 1))
+        model = ContextualizedCorrelation(self.c_dim, self.x_dim, base_param_predictor=parambase, base_y_predictor=ybase)
         self._quicktest(model, correlation=True)
 
     def test_correlation_tasksplit(self):
         # Tasksplit Correlation
         parambase = DummyParamPredictor((1,), (1,))
-        model = TasksplitContextualizedCorrelation(self.c_dim, self.x_dim, base_param_predictor=parambase)
+        ybase = DummyYPredictor((1,))
+        model = TasksplitContextualizedCorrelation(self.c_dim, self.x_dim, base_param_predictor=parambase, base_y_predictor=ybase)
         self._quicktest(model, correlation=True)
 
 

--- a/contextualized/regression/tests.py
+++ b/contextualized/regression/tests.py
@@ -9,7 +9,7 @@ from contextualized.regression.trainers import *
 from contextualized.regression import ENCODERS, LINK_FUNCTIONS
 
 
-class DummyBasePredictor:
+class DummyParamPredictor:
     def __init__(self, beta_dim, mu_dim):
         self.beta_dim = beta_dim
         self.mu_dim = mu_dim
@@ -17,6 +17,15 @@ class DummyBasePredictor:
     def predict_params(self, *args):
         n = len(args[0])
         return torch.zeros((n, *self.beta_dim)), torch.zeros((n, *self.mu_dim))
+
+
+class DummyYPredictor:
+    def __init__(self, y_dim):
+        self.y_dim = y_dim
+
+    def predict_y(self, *args):
+        n = len(args[0])
+        return torch.zeros((n, *self.y_dim))
 
 
 class TestRegression(unittest.TestCase):
@@ -96,52 +105,58 @@ class TestRegression(unittest.TestCase):
             link_fn=LINK_FUNCTIONS['logistic'])
         self._quicktest(model)
         
-        dummybase = DummyBasePredictor((self.y_dim, self.x_dim), (self.y_dim, 1))
+        parambase = DummyParamPredictor((self.y_dim, self.x_dim), (self.y_dim, 1))
         model = NaiveContextualizedRegression(self.c_dim, self.x_dim, self.y_dim,
             encoder_kwargs={'width': 25, 'layers': 2, 'link_fn': LINK_FUNCTIONS['softmax']},
-            link_fn=LINK_FUNCTIONS['logistic'], base_predictor=dummybase)
+            link_fn=LINK_FUNCTIONS['logistic'], base_param_predictor=parambase)
+        self._quicktest(model)
+        
+        ybase = DummyYPredictor((self.y_dim, 1))
+        model = NaiveContextualizedRegression(self.c_dim, self.x_dim, self.y_dim,
+            encoder_kwargs={'width': 25, 'layers': 2, 'link_fn': LINK_FUNCTIONS['softmax']},
+            link_fn=LINK_FUNCTIONS['logistic'], base_y_predictor=ybase)
         self._quicktest(model)
 
     def test_subtype(self):
         # Subtype Multivariate
-        dummybase = DummyBasePredictor((self.y_dim, self.x_dim), (self.y_dim, 1))
-        model = ContextualizedRegression(self.c_dim, self.x_dim, self.y_dim, base_predictor=dummybase)
+        parambase = DummyParamPredictor((self.y_dim, self.x_dim), (self.y_dim, 1))
+        model = ContextualizedRegression(self.c_dim, self.x_dim, self.y_dim, base_param_predictor=parambase)
         self._quicktest(model)
 
     def test_multitask(self):
         # Multitask Multivariate
-        dummybase = DummyBasePredictor((self.x_dim,), (1,))
-        model = MultitaskContextualizedRegression(self.c_dim, self.x_dim, self.y_dim, base_predictor=dummybase)
+        parambase = DummyParamPredictor((self.x_dim,), (1,))
+        model = MultitaskContextualizedRegression(self.c_dim, self.x_dim, self.y_dim, base_param_predictor=parambase)
         self._quicktest(model)
 
     def test_tasksplit(self):
         # Tasksplit Multivariate
-        dummybase = DummyBasePredictor((self.x_dim,), (1,))
-        model = TasksplitContextualizedRegression(self.c_dim, self.x_dim, self.y_dim, base_predictor=dummybase)
+        parambase = DummyParamPredictor((self.x_dim,), (1,))
+        model = TasksplitContextualizedRegression(self.c_dim, self.x_dim, self.y_dim, base_param_predictor=parambase)
         self._quicktest(model)
 
     def test_univariate_subtype(self):
         # Naive Univariate
-        dummybase = DummyBasePredictor((self.y_dim, self.x_dim, 1), (self.y_dim, self.x_dim, 1))
-        model = ContextualizedUnivariateRegression(self.c_dim, self.x_dim, self.y_dim, base_predictor=dummybase)
+        parambase = DummyParamPredictor((self.y_dim, self.x_dim, 1), (self.y_dim, self.x_dim, 1))
+        model = ContextualizedUnivariateRegression(self.c_dim, self.x_dim, self.y_dim, base_param_predictor=parambase)
         self._quicktest(model, univariate=True)
 
     def test_univariate_tasksplit(self):
         # Tasksplit Univariate
-        dummybase = DummyBasePredictor((1,), (1,))
-        model = TasksplitContextualizedUnivariateRegression(self.c_dim, self.x_dim, self.y_dim, base_predictor=dummybase)
+        parambase = DummyParamPredictor((1,), (1,))
+        model = TasksplitContextualizedUnivariateRegression(self.c_dim, self.x_dim, self.y_dim, base_param_predictor=parambase)
         self._quicktest(model, univariate=True)
 
     def test_correlation_subtype(self):
         # Correlation
-        dummybase = DummyBasePredictor((self.x_dim, self.x_dim, 1), (self.x_dim, self.x_dim, 1))
-        model = ContextualizedCorrelation(self.c_dim, self.x_dim, base_predictor=dummybase)
+        parambase = DummyParamPredictor((self.x_dim, self.x_dim, 1), (self.x_dim, self.x_dim, 1))
+        model = ContextualizedCorrelation(self.c_dim, self.x_dim, base_param_predictor=parambase)
         self._quicktest(model, correlation=True)
 
     def test_correlation_tasksplit(self):
         # Tasksplit Correlation
-        dummybase = DummyBasePredictor((1,), (1,))
-        model = TasksplitContextualizedCorrelation(self.c_dim, self.x_dim, base_predictor=dummybase)
+        parambase = DummyParamPredictor((1,), (1,))
+        model = TasksplitContextualizedCorrelation(self.c_dim, self.x_dim, base_param_predictor=parambase)
         self._quicktest(model, correlation=True)
 
 


### PR DESCRIPTION
Added a base predictor kwarg to ContextualizedRegressionBase and enabled for all `regression` and `easy` classes.
Added base predictor kwarg quicktests to `regression` and `easy`
Resolves #89 for `regression` and `easy`