### PR TITLE
reorganize README, add ACKNOWLEDGEMENTS

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -1,0 +1,8 @@
+Thank you to everyone here for your impactful contributions!
+
+- Maruan Al-Shedivat
+- Bryon Aragam
+- Rich Caruana
+- Avinava Dubey
+- Manolis Kellis
+- Eric Xing

--- a/README.md
+++ b/README.md
@@ -1,20 +1,40 @@
 ![Preview](contextualized_logo.png)
+#
+![License](https://img.shields.io/github/license/cnellington/contextualized.svg?style=flat-square)
+![Maintenance](https://img.shields.io/maintenance/yes/2022?style=flat-square)
 
 A statistical machine learning toolbox for estimating models, distributions, and functions with context-specific parameters.
 
-Take a look at the [main demo](demos/main_demo.ipynb) for a complete overview with code, or the [easy demo](demos/Easy-demo/easy_demo.ipynb) for a quickstart with sklearn-style wrappers!
-
-Implemented by [Caleb Ellington](https://calebellington.com/) (CMU) and [Ben Lengerich](http://web.mit.edu/~blengeri/www/index.shtml) (MIT).
+Context-specific parameters are essential for:
+- Finding hidden heterogeneity in data -- are all samples the same?
+- Identifying context-specific predictors -- are there different reasons for outcomes?
+- Domain adaptation -- can our learned models extrapolate to new contexts?
 
 ## Install and Use Contextualized
 ```
 pip install git+https://github.com/cnellington/Contextualized.git
 ```
 
+Take a look at the [main demo](demos/main_demo.ipynb) for a complete overview with code, or the [easy demo](demos/Easy-demo/easy_demo.ipynb) for a quickstart with sklearn-style wrappers!
+
+### Quick Start
+
+#### Build a Contextualized Model
+```
+from contextualized.easy import ContextualizedRegressor
+model = ContextualizedRegressor()
+model.fit(C, X, Y)
+```
+
+#### Predict Context-Specific Parameters
+```
+model.predict_params(C)
+```
+
 ## Contextualized Family
-Context-dependent modeling is a universal problem, but every domain presents unique challenges and opportunities. 
+Context-dependent modeling is a universal problem, but every domain presents unique challenges and opportunities.
 Here are some layers that others have added on top of Contextualized.
-Feel free to add your own page(s) by sending a PR.
+Feel free to add your own page(s) by sending a PR or request an improvement by creating an issue. See [CONTRIBUTING.md](https://github.com/cnellington/Contextualized/blob/main/CONTRIBUTING.md) for more information about the process of contributing to this project.
 
 <table>
 <tr>
@@ -23,14 +43,24 @@ Feel free to add your own page(s) by sending a PR.
 </tr>
 </table>
 
+
+## Acknowledgements
+
+ContextualizedML was originally implemented by [Caleb Ellington](https://calebellington.com/) (CMU) and [Ben Lengerich](http://web.mit.edu/~blengeri/www/index.shtml) (MIT).
+
+Many people have helped. Check out [ACKNOWLEDGEMENTS.md](https://github.com/cnellington/Contextualized/blob/main/ACKNOWLEDGEMENTS.md)!
+
+
 ## Related Publications and Pre-prints
-Lengerich, Benjamin J., Mark E. Nunnally, Yin Aphinyanaphongs, Caleb Ellington, and Rich Caruana. 2022. “Automated Interpretable Discovery of Heterogeneous Treatment Effectiveness: A COVID-19 Case Study.” Journal of Biomedical Informatics, April, 104086. https://www.sciencedirect.com/science/article/pii/S1532046422001022
+- [Automated Interpretable Discovery of Heterogeneous Treatment Effectiveness: A COVID-19 Case Study](https://www.sciencedirect.com/science/article/pii/S1532046422001022)
+- [NOTMAD: Estimating Bayesian Networks with Sample-Specific Structures and Parameters](http://arxiv.org/abs/2111.01104)
+- [Discriminative Subtyping of Lung Cancers from Histopathology Images via Contextual Deep Learning](https://www.medrxiv.org/content/10.1101/2020.06.25.20140053v1.abstract)
+- [Personalized Survival Prediction with Contextual Explanation Networks](http://arxiv.org/abs/1801.09810)
+- [Contextual Explanation Networks](https://jmlr.org/papers/v21/18-856.html)
 
-Lengerich, Ben, Caleb Ellington, Bryon Aragam, Eric P. Xing, and Manolis Kellis. 2021. “NOTMAD: Estimating Bayesian Networks with Sample-Specific Structures and Parameters.” arXiv [stat.ML]. arXiv. http://arxiv.org/abs/2111.01104.
 
-Lengerich, Benjamin J., Maruan Al-Shedivat, Amir Alavi, Jennifer Williams, Sami Labbaki, and Eric P. Xing. 2020. “Discriminative Subtyping of Lung Cancers from Histopathology Images via Contextual Deep Learning.” medRxiv. https://www.medrxiv.org/content/10.1101/2020.06.25.20140053v1.abstract.
+## Videos
+- [Sample-Specific Models for Interpretable Analysis with Applications to Disease Subtyping](http://www.birs.ca/events/2022/5-day-workshops/22w5055/videos/watch/202205051559-Lengerich.html)
 
-Al-Shedivat, Maruan, Avinava Dubey, and Eric P. Xing. 2018. “Personalized Survival Prediction with Contextual Explanation Networks.” arXiv [cs.LG]. arXiv. http://arxiv.org/abs/1801.09810.
-
-Al-Shedivat, Maruan, Avinava Dubey, and Eric Xing. 2020. “Contextual Explanation Networks.” Journal of Machine Learning Research: JMLR 21 (194): 1–44.
-https://jmlr.org/papers/v21/18-856.html
+## Contact Us
+Please get in touch with any questions, feature requests, or applications.


### PR DESCRIPTION
Reorganizes the README file with cleaned-up versions of the related papers, and adds a very short example of the `easy` usage to the README. I would like for this to someday include images/gifs of the model in action and being analyzed so that new users can quickly get an idea of what is possible with contextualized models. Also includes a link to a video presentation describing contextualized models.

Also adds a file ACKNOWLEDMENTS.md, where we will list names of people who have contributed to the project.