### PR TITLE
Hidden layers arg fix + enabling linear encoders

### DIFF
--- a/contextualized/modules.py
+++ b/contextualized/modules.py
@@ -11,6 +11,8 @@ class SoftSelect(nn.Module):
     """
     def __init__(self, in_dims, out_shape):
         super(SoftSelect, self).__init__()
+        self.in_dims = in_dims
+        self.out_shape = out_shape
         init_mat = torch.rand(list(out_shape) + list(in_dims)) * 2e-2 - 1e-2
         self.archetypes = nn.parameter.Parameter(init_mat, requires_grad=True)
 
@@ -26,17 +28,35 @@ class SoftSelect(nn.Module):
             batch_archetypes = torch.matmul(batch_archetypes, batch_w).squeeze(-1)
         return batch_archetypes
 
+    def _cycle_dims(self, tensor, n):
+        """
+        Cycle tensor dimensions from front to back for n steps
+        """
+        for _ in range(n):
+            tensor = tensor.unsqueeze(0).transpose(0, -1).squeeze(-1)
+        return tensor
 
-class Explainer(nn.Module):
+    def get_archetypes(self):
+        """
+        Returns archetype parameters: (*in_dims, *out_shape)
+        """
+        return self._cycle_dims(self.archetypes, len(self.in_dims))
+
+    def set_archetypes(self, archetypes):
+        """
+        Sets archetype parameters
+
+        Requires archetypes.shape == (*in_dims, *out_shape)
+        """
+        self.archetypes = nn.parameter.Parameter(self._cycle_dims(archetypes, len(self.out_shape)), requires_grad=True)
+
+
+class Explainer(SoftSelect):
     """
     2D subtype-archetype parameter sharing
     """
     def __init__(self, k, out_shape):
-        super(Explainer, self).__init__()
-        self.softselect = SoftSelect((k, ), out_shape)
-
-    def forward(self, batch_subtypes):
-        return self.softselect(batch_subtypes)
+        super().__init__((k, ), out_shape)
 
 
 class MLP(nn.Module):
@@ -79,7 +99,7 @@ class NGAM(nn.Module):
         return self.link_fn(ret)
 
 
-if __name__ == '__main__':
+if __name__ == '__main__': 
     n = 100
     x_dim = 10
     y_dim = 5
@@ -87,9 +107,39 @@ if __name__ == '__main__':
     width = 50
     layers = 5
     x = torch.rand((n, x_dim))
-
+    
     mlp = MLP(x_dim, y_dim, width, layers)
     mlp(x)
 
     ngam = NGAM(x_dim, y_dim, width, layers)
     ngam(x)
+    
+    in_dims = (3, 4)
+    out_shape = (5, 6)
+    z1 = torch.randn(100, 3)
+    z2 = torch.randn(100, 4)
+    softselect = SoftSelect(in_dims, out_shape)
+    softselect(z1, z2)
+
+    precycle_vals = softselect.archetypes
+    assert precycle_vals.shape == (*out_shape, *in_dims)
+    postcycle_vals = softselect.get_archetypes()
+    assert postcycle_vals.shape == (*in_dims, *out_shape)
+    softselect.set_archetypes(torch.randn(*in_dims, *out_shape))
+    assert (softselect.archetypes != precycle_vals).any()
+    softselect.set_archetypes(postcycle_vals)
+    assert (softselect.archetypes == precycle_vals).all()
+
+    in_dims = (3, )
+    explainer = Explainer(in_dims[0], out_shape)
+    explainer(z1)
+    
+    precycle_vals = explainer.archetypes
+    assert precycle_vals.shape == (*out_shape, *in_dims)
+    postcycle_vals = explainer.get_archetypes()
+    assert postcycle_vals.shape == (*in_dims, *out_shape)
+    explainer.set_archetypes(torch.randn(*in_dims, *out_shape))
+    assert (explainer.archetypes != precycle_vals).any()
+    explainer.set_archetypes(postcycle_vals)
+    assert (explainer.archetypes == precycle_vals).all()
+

--- a/contextualized/modules.py
+++ b/contextualized/modules.py
@@ -46,9 +46,10 @@ class MLP(nn.Module):
     def __init__(self, input_dim, output_dim, width, layers, activation=nn.ReLU, link_fn=identity_link):
         super(MLP, self).__init__()
         if layers > 0:
-            mlp_layers = [nn.Linear(input_dim, width), activation()] + \
-                    [layer for _ in range(0, layers - 1) for layer in (nn.Linear(width, width), activation())] + \
-                    [nn.Linear(width, output_dim)]
+            mlp_layers = [nn.Linear(input_dim, width), activation()]
+            for _ in range(layers - 1):
+                mlp_layers += [nn.Linear(width, width), activation()]
+            mlp_layers.append(nn.Linear(width, output_dim))
         else:  # Linear encoder
             mlp_layers = [nn.Linear(input_dim, output_dim)]
         self.mlp = nn.Sequential(*mlp_layers)

--- a/contextualized/modules.py
+++ b/contextualized/modules.py
@@ -46,8 +46,9 @@ class MLP(nn.Module):
     def __init__(self, input_dim, output_dim, width, layers, activation=nn.ReLU, link_fn=identity_link):
         super(MLP, self).__init__()
         if layers > 0:
-            hidden_layers = lambda: [layer for _ in range(0, layers - 1) for layer in (nn.Linear(width, width), activation())]
-            mlp_layers = [nn.Linear(input_dim, width), activation()] + hidden_layers() + [nn.Linear(width, output_dim)]
+            mlp_layers = [nn.Linear(input_dim, width), activation()] + \
+                    [layer for _ in range(0, layers - 1) for layer in (nn.Linear(width, width), activation())] + \
+                    [nn.Linear(width, output_dim)]
         else:  # Linear encoder
             mlp_layers = [nn.Linear(input_dim, output_dim)]
         self.mlp = nn.Sequential(*mlp_layers)
@@ -66,7 +67,7 @@ class NGAM(nn.Module):
         super(NGAM, self).__init__()
         self.intput_dim = input_dim
         self.output_dim = output_dim
-        self.nams = nn.ModuleList([MLP(1, output_dim, width, layers, activation=activation, link_fn=link_fn) for _ in range(input_dim)])
+        self.nams = nn.ModuleList([MLP(1, output_dim, width, layers, activation=activation, link_fn=identity_link) for _ in range(input_dim)])
         self.link_fn = link_fn
 
     def forward(self, x):

--- a/contextualized/modules.py
+++ b/contextualized/modules.py
@@ -78,35 +78,6 @@ class NGAM(nn.Module):
         return self.link_fn(ret)
 
 
-class NGAMOE(nn.Module):
-    """
-    NGAM with Mixture of Experts
-    Each additive model includes a mixture of experts + gating function for the parameters of the final linear layer
-    """
-    def __init__(self, input_dim, output_dim, k, width, layers, activation=nn.ReLU, gating_fn=identity, link_fn=identity_link):
-        super(NGAMOE, self).__init__()
-        self.intput_dim = input_dim
-        self.output_dim = output_dim
-        hidden_layers = lambda: [layer for _ in range(0, layers - 1) for layer in (nn.Linear(width, width), activation())]
-        nam_layers = lambda: [nn.Linear(1, width), activation()] + hidden_layers() + [nn.Linear(width, width), activation()]
-        expert_layers = lambda: [nn.Linear(1, width), activation()] + hidden_layers() + [nn.Linear(width, k), activation()]
-        self.nams = nn.ModuleList([nn.Sequential(*nam_layers()) for _ in range(input_dim)])
-        self.experts = nn.ModuleList([nn.Sequential(*expert_layers()) for _ in range(input_dim)])
-        self.explainer = SoftSelect((k, ), (output_dim, width))
-        self.gating_fn = gating_fn
-        self.link_fn = link_fn
-
-    def forward(self, x):
-        batch_size = x.shape[0]
-        ret = torch.zeros((batch_size, self.output_dim))
-        for i, (nam, expert) in enumerate(zip(self.nams, self.experts)):
-            final_gating = self.gating_fn(expert(x[:, i].unsqueeze(-1)))
-            final_linear = self.explainer(final_gating)
-            final_hidden = nam(x[:, i].unsqueeze(-1))
-            ret += torch.matmul(final_linear, final_hidden.unsqueeze(-1)).squeeze(-1)
-        return self.link_fn(ret)
-
-
 if __name__ == '__main__':
     n = 100
     x_dim = 10
@@ -121,6 +92,3 @@ if __name__ == '__main__':
 
     ngam = NGAM(x_dim, y_dim, width, layers)
     ngam(x)
-
-    ngamoe = NGAMOE(x_dim, y_dim, k, width, layers)
-    ngamoe(x)

--- a/contextualized/regression/metamodels.py
+++ b/contextualized/regression/metamodels.py
@@ -12,7 +12,7 @@ class NaiveMetamodel(nn.Module):
     (C) --> {beta, mu} --> (X, Y)
     """
     def __init__(self, context_dim, x_dim, y_dim, univariate=False, encoder_type='mlp',
-                 encoder_kwargs={'width': 25, 'layers': 2, 'link_fn': LINK_FUNCTIONS['identity']}):
+                 encoder_kwargs={'width': 25, 'layers': 1, 'link_fn': LINK_FUNCTIONS['identity']}):
         """
         context_dim (int): dimension of flattened context
         x_dim (int): dimension of flattened features
@@ -50,7 +50,7 @@ class SubtypeMetamodel(nn.Module):
     Z: latent variable, causal parent of both the context and regression model
     """
     def __init__(self, context_dim, x_dim, y_dim, univariate=False, num_archetypes=10, encoder_type='mlp',
-                 encoder_kwargs={'width': 25, 'layers': 2, 'link_fn': LINK_FUNCTIONS['identity']}):
+                 encoder_kwargs={'width': 25, 'layers': 1, 'link_fn': LINK_FUNCTIONS['identity']}):
         """
         context_dim (int): dimension of flattened context
         x_dim (int): dimension of flattened features
@@ -90,7 +90,7 @@ class MultitaskMetamodel(nn.Module):
     Z: latent variable, causal parent of the context, regression model, and task (T)
     """
     def __init__(self, context_dim, x_dim, y_dim, univariate=False, num_archetypes=10, encoder_type='mlp',
-                 encoder_kwargs={'width': 25, 'layers': 2, 'link_fn': LINK_FUNCTIONS['identity']}):
+                 encoder_kwargs={'width': 25, 'layers': 1, 'link_fn': LINK_FUNCTIONS['identity']}):
         """
         context_dim (int): dimension of flattened context
         x_dim (int): dimension of flattened features
@@ -135,9 +135,9 @@ class TasksplitMetamodel(nn.Module):
     def __init__(self, context_dim, x_dim, y_dim, univariate=False,
             context_archetypes=10, task_archetypes=10,
             context_encoder_type='mlp',
-            context_encoder_kwargs={'width': 25, 'layers': 2, 'link_fn': LINK_FUNCTIONS['softmax']},
+            context_encoder_kwargs={'width': 25, 'layers': 1, 'link_fn': LINK_FUNCTIONS['softmax']},
             task_encoder_type='mlp',
-            task_encoder_kwargs={'width': 25, 'layers': 2, 'link_fn': LINK_FUNCTIONS['identity']},
+            task_encoder_kwargs={'width': 25, 'layers': 1, 'link_fn': LINK_FUNCTIONS['identity']},
             ):
         """
         context_dim (int): dimension of flattened context

--- a/contextualized/regression/tests.py
+++ b/contextualized/regression/tests.py
@@ -89,6 +89,12 @@ class TestRegression(unittest.TestCase):
             encoder_kwargs={'width': 25, 'layers': 2, 'link_fn': LINK_FUNCTIONS['identity']},
             link_fn=LINK_FUNCTIONS['identity'])
         self._quicktest(model)
+        
+        model = NaiveContextualizedRegression(self.c_dim, self.x_dim, self.y_dim,
+            encoder_type='ngam',
+            encoder_kwargs={'width': 25, 'layers': 2, 'link_fn': LINK_FUNCTIONS['identity']},
+            link_fn=LINK_FUNCTIONS['identity'])
+        self._quicktest(model)
 
         model = NaiveContextualizedRegression(self.c_dim, self.x_dim, self.y_dim,
             encoder_kwargs={'width': 25, 'layers': 2, 'link_fn': LINK_FUNCTIONS['softmax']},


### PR DESCRIPTION
`layers` now specifies the number of hidden layers in the encoders. (seems to have previously specified the number of dense connections, which was 2 by default with 1 hidden layer in between)

Users can now specify a linear encoder by using an MLP or NGAM with <1 layers, which defaults to a single matrix of trainable weights with no activations.