### PR TITLE
[WIP] Remove Tensorflow from Dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,12 @@ setuptools.setup(name='contextualized',
         'matplotlib',
         'pandas',
         'umap-learn',
-        'interpret',
-        'tensorflow>=2.4.0',
-        'tensorflow-addons',
         'numpy>=1.19.2',
         'ipywidgets',
         'torchvision',
         'dill',
     ],
+    extras_require = {
+        'notmad_tensorflow': ['tensorflow>=2.4.0', 'tensorflow-addons'],
+    }
 )


### PR DESCRIPTION
Since tensorflow can have some tricky install behavior, and we only use it for old NOTMAD, we can move its requirement to `extras_require`. This way, we can install the old NOTMAD dependencies with 'pip install contextualized[notmad_tensorflow]`. However, this PR is a WIP and should not be pulled yet because the unit tests rely on the tensorflow NOTMAD version.

Also removes the interpret dependency since it's not actually used.