### PR TITLE
Fix pylint dependencies

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,6 +18,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
+        pip install .
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py')

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Context-specific parameters are essential for:
 
 ## Install and Use Contextualized
 ```
-pip install git+https://github.com/cnellington/Contextualized.git
+pip install contextualized-ml
 ```
 
 Take a look at the [main demo](docs/demos/main_demo.ipynb) for a complete overview with code, or the [easy demo](docs/demos/Easy-demo/easy_demo.ipynb) for a quickstart with sklearn-style wrappers!

--- a/docs/installation.ipynb
+++ b/docs/installation.ipynb
@@ -12,7 +12,7 @@
     "```{tab-item} pip\n",
     "\n",
     "`\n",
-    "pip install https://github.com/cnellington/contextualized.git\n",
+    "pip install contextualized-ml\n",
     "`\n",
     "\n",
     "```\n",
@@ -27,6 +27,14 @@
     "\n",
     "Now, let's walk through an example of Contextualized analysis."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9dce20f5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     description=DESCRIPTION,
     url="https://github.com/cnellington/contextualized",
     packages=find_packages(),
-    version=VERSION,
     install_requires=[
         'lightning',
         'pytorch-lightning',

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,18 @@
-import setuptools
+"""
+Setup and requirements for Contextualized.ML
+"""
 
-setuptools.setup(name='contextualized',
-    packages=[
-        'contextualized',
-        'contextualized.regression',
-        'contextualized.dags',
-        'contextualized.easy',
-    ],
+from setuptools import find_packages, setup
+
+DESCRIPTION = "An ML toolbox for estimating context-specific parameters."
+
+setup(
+    name='contextualized',
     version='0.2.1',
+    author="Contextualized.ML team",
+    description=DESCRIPTION,
+    url="https://github.com/cnellington/contextualized",
+    packages=find_packages(),
     install_requires=[
         'lightning',
         'torch',
@@ -16,5 +21,6 @@ setuptools.setup(name='contextualized',
         'scikit-learn',
         'igraph',
         'dill',
+        'pytorch_lightning'
     ],
 )


### PR DESCRIPTION
Pylint on Github is failing when it runs into dependencies because it isn't being told to install the package and dependencies before linting. This simple change should fix that.