### PR TITLE
Tiny bugfix to plot homogeneous_predictor_effects

### DIFF
--- a/contextualized/analysis/effects.py
+++ b/contextualized/analysis/effects.py
@@ -248,7 +248,7 @@ def plot_homogeneous_predictor_effects(
                 x_encoder=encoder,
                 x_means=x_means,
                 x_stds=x_stds,
-                xlabel=f"{kwargs.get('xlabel_prefix',  '')} {X.columns[k]}",
+                xlabel=f"{kwargs.get('xlabel_prefix',  '')} {X.columns[j]}",
                 **kwargs,
             )
 


### PR DESCRIPTION
Was plotting the wrong label on the x axis, fixed.