### PR TITLE
fit_intercept and metamodel_type kwargs for regression

### DIFF
--- a/contextualized/dags/tests.py
+++ b/contextualized/dags/tests.py
@@ -121,7 +121,7 @@ class TestNOTMAD(unittest.TestCase):
         val_dataloader = model.dataloader(
             self.C_val, self.X_val, batch_size=10, num_workers=1
         )
-        trainer = GraphTrainer(max_epochs=n_epochs, callbacks=[], deterministic=True)
+        trainer = GraphTrainer(max_epochs=n_epochs, callbacks=[], deterministic=True, enable_progress_bar=False)
         preds_train = trainer.predict_params(
             model, train_dataloader, project_to_dag=True
         )

--- a/contextualized/easy/wrappers/SKLearnWrapper.py
+++ b/contextualized/easy/wrappers/SKLearnWrapper.py
@@ -469,7 +469,7 @@ class SKLearnWrapper:
                 for f in organized_kwargs["trainer"]["callback_constructors"]
             ]
             del my_trainer_kwargs["callback_constructors"]
-            trainer = self.trainer_constructor(**my_trainer_kwargs)
+            trainer = self.trainer_constructor(**my_trainer_kwargs, enable_progress_bar=False)
             checkpoint_callback = my_trainer_kwargs["callbacks"][1]
             os.makedirs(checkpoint_callback.dirpath, exist_ok=True)
             try:

--- a/contextualized/regression/metamodels.py
+++ b/contextualized/regression/metamodels.py
@@ -263,3 +263,14 @@ class TasksplitMetamodel(nn.Module):
         beta = W[:, :-1]
         mu = W[:, -1:]
         return beta, mu
+
+
+SINGLE_TASK_METAMODELS = {
+    'naive': NaiveMetamodel,
+    'subtype': SubtypeMetamodel,
+}
+
+MULTITASK_METAMODELS = {
+    'multitask': MultitaskMetamodel,
+    'tasksplit': TasksplitMetamodel,
+}

--- a/contextualized/regression/tests.py
+++ b/contextualized/regression/tests.py
@@ -332,6 +332,59 @@ class TestRegression(unittest.TestCase):
         )
         self._quicktest(model, markov=True)
 
+    def test_metamodel_switch(self):
+        """
+        Test switching between meta-models.
+        """
+        parambase = DummyParamPredictor((self.y_dim, self.x_dim), (self.y_dim, 1))
+        ybase = DummyYPredictor((self.y_dim, 1))
+        model = ContextualizedRegression(
+            self.c_dim,
+            self.x_dim,
+            self.y_dim,
+            metamodel_type="naive",
+            base_param_predictor=parambase,
+            base_y_predictor=ybase,
+        )
+        self._quicktest(model)
+
+        parambase = DummyParamPredictor((self.y_dim, self.x_dim), (self.y_dim, 1))
+        ybase = DummyYPredictor((self.y_dim, 1))
+        model = ContextualizedRegression(
+            self.c_dim,
+            self.x_dim,
+            self.y_dim,
+            metamodel_type="subtype",
+            base_param_predictor=parambase,
+            base_y_predictor=ybase,
+        )
+        self._quicktest(model)
+
+    def test_fit_intercept(self):
+        """
+        Test switching between meta-models.
+        """
+        parambase = DummyParamPredictor((self.y_dim, self.x_dim), (self.y_dim, 1))
+        ybase = DummyYPredictor((self.y_dim, 1))
+        model = ContextualizedRegression(
+            self.c_dim,
+            self.x_dim,
+            self.y_dim,
+            metamodel_type="naive",
+            fit_intercept=False,
+            base_param_predictor=parambase,
+            base_y_predictor=ybase,
+        )
+        dataloader = model.dataloader(
+            self.C, self.X, self.Y, batch_size=self.batch_size
+        )
+        trainer = RegressionTrainer()
+        beta_preds, mu_preds = trainer.predict_params(model, dataloader)
+        assert (mu_preds == 0).all()
+        self._quicktest(model)
+        beta_preds, mu_preds = trainer.predict_params(model, dataloader)
+        assert (mu_preds == 0).all()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/contextualized/regression/tests.py
+++ b/contextualized/regression/tests.py
@@ -59,17 +59,17 @@ class TestRegression(unittest.TestCase):
         print(f"\n{type(model)} quicktest")
         if correlation:
             dataloader = model.dataloader(self.C, self.X, batch_size=self.batch_size)
-            trainer = CorrelationTrainer(max_epochs=self.epochs)
+            trainer = CorrelationTrainer(max_epochs=self.epochs, enable_progress_bar=False)
             y_true = np.tile(self.X[:, :, np.newaxis], (1, 1, self.X.shape[-1]))
         elif markov:
             dataloader = model.dataloader(self.C, self.X, batch_size=self.batch_size)
-            trainer = MarkovTrainer(max_epochs=self.epochs)
+            trainer = MarkovTrainer(max_epochs=self.epochs, enable_progress_bar=False)
             y_true = self.X
         else:
             dataloader = model.dataloader(
                 self.C, self.X, self.Y, batch_size=self.batch_size
             )
-            trainer = RegressionTrainer(max_epochs=self.epochs)
+            trainer = RegressionTrainer(max_epochs=self.epochs, enable_progress_bar=False)
             if univariate:
                 y_true = np.tile(self.Y[:, :, np.newaxis], (1, 1, self.X.shape[-1]))
             else:
@@ -378,7 +378,7 @@ class TestRegression(unittest.TestCase):
         dataloader = model.dataloader(
             self.C, self.X, self.Y, batch_size=self.batch_size
         )
-        trainer = RegressionTrainer()
+        trainer = RegressionTrainer(enable_progress_bar=False)
         beta_preds, mu_preds = trainer.predict_params(model, dataloader)
         assert (mu_preds == 0).all()
         self._quicktest(model)


### PR DESCRIPTION
- Added fit_intercept kwarg to all regression lightning modules. Setting False does not change output format, but all output mus will be zero.
- Added metamodel_type kwargs to single-task regression modules (ContextualizedRegression, univariate, correlation, markov, neighborhood selection) which supports both Naive and Subtype metamodels.