### PR TITLE
Fix typo in index.html

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -101,7 +101,7 @@
                         <img class="card-img-top mx-auto pt-5 icon-blue" src="images/icon-blocks-blue.png">
                         <img class="card-img-top mx-auto pt-5 inactive icon-white" src="images/icon-blocks.png">
                         <div class="card-body px-md-5">
-                            <p class="card-text gray-text masthead-text text-center px-sm-0 px-lg-5 pb-4">Building blocks to support extending meta-models to contextualize your application-specific mdoel</p>
+                            <p class="card-text gray-text masthead-text text-center px-sm-0 px-lg-5 pb-4">Building blocks to support extending meta-models to contextualize your application-specific model</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Fixed a tiny typo in `index.html`.