### PR TITLE
Fixes for NOTMAD wrapper and param defaults

### DIFF
--- a/contextualized/dags/lightning_modules.py
+++ b/contextualized/dags/lightning_modules.py
@@ -28,7 +28,7 @@ DAG_LOSSES = {
 }
 DEFAULT_DAG_LOSS_TYPE = "NOTEARS"
 DEFAULT_DAG_LOSS_PARAMS = {
-    "NOTEARS": {"alpha": 1e-1, "rho": 1e-2},
+    "NOTEARS": {"alpha": 1e-1, "rho": 1e-2, "tol": 0.25, "use_dynamic_alpha_rho": False},
     "DAGMA": {"s": 1, "alpha": 1e0},
     "poly": {},
 }
@@ -142,13 +142,16 @@ class NOTMAD(pl.LightningModule):
         # DAG regularizers
         self.ss_dag_params = sample_specific_loss_params["dag"].get(
             "params",
-            DEFAULT_DAG_LOSS_PARAMS[sample_specific_loss_params["dag"]["loss_type"]],
+            DEFAULT_DAG_LOSS_PARAMS[sample_specific_loss_params["dag"]["loss_type"]].copy(),
         )
-        self.arch_dag_params = archetype_loss_params["dag"].get(
-            "params", DEFAULT_DAG_LOSS_PARAMS[archetype_loss_params["dag"]["loss_type"]]
-        )
-        self.val_dag_loss_params = {"alpha": 1e0, "rho": 1e0}
+        
 
+        self.arch_dag_params = archetype_loss_params["dag"].get(
+            "params", 
+            DEFAULT_DAG_LOSS_PARAMS[archetype_loss_params["dag"]["loss_type"]].copy()
+        )
+
+        self.val_dag_loss_params = {"alpha": 1e0, "rho": 1e0}
         self.ss_dag_loss = DAG_LOSSES[sample_specific_loss_params["dag"]["loss_type"]]
         self.arch_dag_loss = DAG_LOSSES[archetype_loss_params["dag"]["loss_type"]]
 
@@ -409,7 +412,7 @@ class NOTMAD(pl.LightningModule):
         """
         if (
             dag_params.get("use_dynamic_alpha_rho", False)
-            and epoch_dag_loss > dag_params["tol"] * dag_params["h_old"]
+            and epoch_dag_loss > dag_params.get("tol", .25) * dag_params.get("h_old", 0)
             and dag_params["alpha"] < 1e12
             and dag_params["rho"] < 1e12
         ):

--- a/contextualized/easy/ContextualizedNetworks.py
+++ b/contextualized/easy/ContextualizedNetworks.py
@@ -82,7 +82,7 @@ class ContextualizedCorrelationNetworks(ContextualizedNetworks):
             for j in range(X.shape[-1]):
                 tiled_xi = np.array([X[:, i] for _ in range(len(betas))])
                 tiled_xj = np.array([X[:, j] for _ in range(len(betas))])
-                residuals = tiled_xi - betas[:, :, i, j] * tiled_xj + mus[:, :, i, j]
+                residuals = tiled_xi - betas[:, :, i, j] * tiled_xj - mus[:, :, i, j]
                 mses += residuals**2 / (X.shape[-1] ** 2)
         if not individual_preds:
             mses = np.mean(mses, axis=0)


### PR DESCRIPTION
- `copy()` used to prevent arch and ss from sharing param dictionary
- additional convenience params for setting dynamic alpha rho and tolerance
- set default tolerance and h_old if not specified as convenience params `_maybe_use_dynamic_alpha_rho()`
- set default notears params