### PR TITLE
[Fix] Add automatic normalization support for C and X in ContextualizedRegressor

### DIFF
--- a/contextualized/analysis/effects.py
+++ b/contextualized/analysis/effects.py
@@ -8,7 +8,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from contextualized.easy.wrappers import SKLearnWrapper
-
+from contextualized.utils import inverse_transform_preserve_df
 
 def simple_plot(
     x_vals: List[Union[float, int]],
@@ -253,6 +253,7 @@ def plot_boolean_vars(names, y_mean, y_err, **kwargs):
 def plot_homogeneous_context_effects(
     model: SKLearnWrapper,
     C: np.ndarray,
+    inverse_transform: bool = True, # inverse normalization to make axes meaningful
     **kwargs,
 ) -> None:
     """
@@ -278,6 +279,16 @@ def plot_homogeneous_context_effects(
     Returns:
         None
     """
+
+    # if normalization is implemented, we hope to inverse_transform and show original context axis
+    if inverse_transform and getattr(model, "normalize", False):
+        if hasattr(model, "scaler_C") and model.scaler_C is not None:
+            # C = model.scaler_C.inverse_transform(C)
+            # C = inverse_transform_preserve_df(model.scaler_C, C)
+            C = inverse_transform_preserve_df(model.scaler_C, C, reference=kwargs.get("original_C"))
+
+
+
     c_vis, effects = get_homogeneous_context_effects(model, C, **kwargs)
     # effects.shape is (n_context, n_bootstraps, n_context_vals, n_outcomes)
     for outcome in range(effects.shape[-1]):
@@ -322,6 +333,7 @@ def plot_homogeneous_predictor_effects(
     model: SKLearnWrapper,
     C: np.ndarray,
     X: np.ndarray,
+    # inverse_transform: bool = True,
     **kwargs,
 ) -> None:
     """
@@ -348,6 +360,11 @@ def plot_homogeneous_predictor_effects(
     Returns:
         None
     """
+
+    if inverse_transform and getattr(model, "normalize", False):
+        if hasattr(model, "scaler_X") and model.scaler_X is not None:
+            X = model.scaler_X.inverse_transform(X)
+
     c_vis = np.zeros_like(C.values)
     x_vis = make_grid_mat(X.values, 1000)
     (betas, _) = model.predict_params(

--- a/contextualized/easy/ContextualizedRegressor.py
+++ b/contextualized/easy/ContextualizedRegressor.py
@@ -30,11 +30,12 @@ class ContextualizedRegressor(SKLearnWrapper):
         l1_ratio (float, optional): Float in range (0.0, 1.0), governs how much the regularization penalizes l1 vs l2 parameter norms. Defaults to 0.0.
     """
 
-    def __init__(self, normalize=True, **kwargs):
+    def __init__(self, **kwargs):
         # for normalization
-        self.normalize = normalize
-        self.scaler_C = None
-        self.scaler_X = None
+        self.normalize = kwargs.pop("normalize", True)
+        # Scalers used to normalize C and X during fit and predict
+        self.scaler_C = None  # StandardScaler for context features (C)
+        self.scaler_X = None  # StandardScaler for input features (X)
 
         self.num_archetypes = kwargs.get("num_archetypes", 0)
         if self.num_archetypes == 0:

--- a/contextualized/regression/datasets.py
+++ b/contextualized/regression/datasets.py
@@ -5,12 +5,20 @@ Data generators used for Contextualized regression training.
 from abc import abstractmethod
 import torch
 from torch.utils.data import IterableDataset
-
+import pandas as pd
 
 class Dataset:
     """Superclass for datastreams (iterators) used to train contextualized.regression models"""
 
     def __init__(self, C, X, Y, dtype=torch.float):
+        # Allow input is dataframe
+        if isinstance(C, pd.DataFrame):
+            C = C.to_numpy()
+        if isinstance(X, pd.DataFrame):
+            X = X.to_numpy()
+        if isinstance(Y, pd.DataFrame):
+            Y = Y.to_numpy()
+        
         self.C = torch.tensor(C, dtype=dtype)
         self.X = torch.tensor(X, dtype=dtype)
         self.Y = torch.tensor(Y, dtype=dtype)

--- a/contextualized/utils.py
+++ b/contextualized/utils.py
@@ -62,3 +62,21 @@ class DummyYPredictor:
         """
         n = len(args[0])
         return torch.zeros((n, *self.y_dim))
+    
+import numpy as np
+from sklearn.preprocessing import StandardScaler
+
+def normalize_data(C, X, return_scaler=False):
+    """
+    Normalize C and X 
+    """
+    scaler_C = StandardScaler()
+    scaler_X = StandardScaler()
+
+    C_norm = scaler_C.fit_transform(C)
+    X_norm = scaler_X.fit_transform(X)
+
+    if return_scaler:
+        return C_norm, X_norm, scaler_C, scaler_X
+    return C_norm, X_norm
+

--- a/contextualized/utils.py
+++ b/contextualized/utils.py
@@ -64,6 +64,7 @@ class DummyYPredictor:
         return torch.zeros((n, *self.y_dim))
     
 import numpy as np
+import pandas as pd
 from sklearn.preprocessing import StandardScaler
 
 def normalize_data(C, X, return_scaler=False):
@@ -76,7 +77,28 @@ def normalize_data(C, X, return_scaler=False):
     C_norm = scaler_C.fit_transform(C)
     X_norm = scaler_X.fit_transform(X)
 
+    if isinstance(C, pd.DataFrame):
+        C_norm = pd.DataFrame(C_norm, columns=C.columns, index=C.index)
+    if isinstance(X, pd.DataFrame):
+        X_norm = pd.DataFrame(X_norm, columns=X.columns, index=X.index)
+
     if return_scaler:
         return C_norm, X_norm, scaler_C, scaler_X
     return C_norm, X_norm
 
+# def inverse_transform_preserve_df(scaler, df):
+#     X_inv = scaler.inverse_transform(df)
+#     if isinstance(df, pd.DataFrame):
+#         return pd.DataFrame(X_inv, columns=df.columns, index=df.index)
+#     return X_inv
+
+def inverse_transform_preserve_df(scaler, df, reference=None):
+    X_inv = scaler.inverse_transform(df)
+
+    if isinstance(df, pd.DataFrame):
+        return pd.DataFrame(X_inv, columns=df.columns, index=df.index)
+
+    if isinstance(reference, pd.DataFrame):
+        return pd.DataFrame(X_inv, columns=reference.columns, index=reference.index)
+
+    return X_inv

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -31,8 +31,7 @@ assert np.allclose(model.scaler_C.mean_, np.mean(C_train, axis=0), atol=1e-1), "
 assert np.allclose(model.scaler_C.scale_, np.std(C_train, axis=0), atol=1e-1), "C normalization failed!"
 assert np.allclose(model.scaler_X.mean_, np.mean(X_train, axis=0), atol=1e-1), "X normalization failed!"
 assert np.allclose(model.scaler_X.scale_, np.std(X_train, axis=0), atol=1e-1), "X normalization failed!"
-print("\n✅ fit() successfully normailized C_train and X_train!")
-
+print("\n✅ fit() successfully normalized C_train and X_train!")
 # predict on test data by trained model
 Y_pred = model.predict(C_test, X_test)
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -27,11 +27,10 @@ model = ContextualizedRegressor(normalize=True)
 # train model on training data
 model.fit(C_train, X_train, Y_train)
 
-assert np.allclose(model.scaler_C.mean_, np.mean(C_train, axis=0), atol=1e-1), "C normalization falied!"
-assert np.allclose(model.scaler_C.scale_, np.std(C_train, axis=0), atol=1e-1), "C normalization falied!"
-assert np.allclose(model.scaler_X.mean_, np.mean(X_train, axis=0), atol=1e-1), "X normalization falied!"
-assert np.allclose(model.scaler_X.scale_, np.std(X_train, axis=0), atol=1e-1), "X normalization falied!"
-
+assert np.allclose(model.scaler_C.mean_, np.mean(C_train, axis=0), atol=1e-1), "C normalization failed!"
+assert np.allclose(model.scaler_C.scale_, np.std(C_train, axis=0), atol=1e-1), "C normalization failed!"
+assert np.allclose(model.scaler_X.mean_, np.mean(X_train, axis=0), atol=1e-1), "X normalization failed!"
+assert np.allclose(model.scaler_X.scale_, np.std(X_train, axis=0), atol=1e-1), "X normalization failed!"
 print("\n✅ fit() successfully normailized C_train and X_train!")
 
 # predict on test data by trained model

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,49 @@
+"""
+test for issue #250
+
+"""
+
+import os
+import sys
+import numpy as np
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from contextualized.easy import ContextualizedRegressor
+
+# generate random un-normalized C and X
+np.random.seed(42)
+C = np.random.rand(100, 5) * 10
+X = np.random.rand(100, 3) * 10
+Y = np.random.rand(100, 1)
+
+# split training/testing data
+C_train, C_test = C[:80], C[80:]
+X_train, X_test = X[:80], X[80:]
+Y_train, Y_test = Y[:80], Y[80:]
+
+# initialized with normalize=True
+model = ContextualizedRegressor(normalize=True)
+
+# train model on training data
+model.fit(C_train, X_train, Y_train)
+
+assert np.allclose(model.scaler_C.mean_, np.mean(C_train, axis=0), atol=1e-1), "C normalization falied!"
+assert np.allclose(model.scaler_C.scale_, np.std(C_train, axis=0), atol=1e-1), "C normalization falied!"
+assert np.allclose(model.scaler_X.mean_, np.mean(X_train, axis=0), atol=1e-1), "X normalization falied!"
+assert np.allclose(model.scaler_X.scale_, np.std(X_train, axis=0), atol=1e-1), "X normalization falied!"
+
+print("\n✅ fit() successfully normailized C_train and X_train!")
+
+# predict on test data by trained model
+Y_pred = model.predict(C_test, X_test)
+
+assert Y_pred is not None, "predict() failed!"
+assert Y_pred.shape == Y_test.shape, "predict() has wrong output shape!"
+
+print("\n✅ predict() ran successfully, un-normalized C_test and X_test were correctly treated!")
+
+print("predicted value:", Y_pred)
+
+# print("model is already trained？", hasattr(model, "scaler_C"), hasattr(model, "scaler_X"))
+# print("scaler_C exists？", model.scaler_C)
+# print("scaler_X exists？", model.scaler_X)

--- a/tests/test_normalize_wrapper.py
+++ b/tests/test_normalize_wrapper.py
@@ -1,0 +1,53 @@
+"""
+test for issue #250
+"""
+
+import os
+import sys
+import numpy as np
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from contextualized.easy.ContextualizedRegressor import ContextualizedRegressor
+from contextualized.easy.wrappers.SKLearnWrapper import SKLearnWrapper  # [修改] 使用 wrapper
+from contextualized.dags.trainers import GraphTrainer  # [修改] 使用 GraphTrainer 替代 TrainerFactory
+from contextualized.regression import NaiveContextualizedRegression
+
+# generate random un-normalized C and X
+np.random.seed(42)
+C = np.random.rand(100, 5) * 10
+X = np.random.rand(100, 3) * 10
+Y = np.random.rand(100, 1)
+
+# split training/testing data
+C_train, C_test = C[:80], C[80:]
+X_train, X_test = X[:80], X[80:]
+Y_train, Y_test = Y[:80], Y[80:]
+
+# initialized wrapper with normalize=True  # [修改] 构造 wrapper 代替原模型
+model = SKLearnWrapper(
+    base_constructor=NaiveContextualizedRegression, 
+    extra_model_kwargs={},
+    extra_data_kwargs={},
+    # trainer_constructor=lambda: GraphTrainer(max_epochs=1),  # [修改] 使用 GraphTrainer
+    trainer_constructor=lambda **kwargs: GraphTrainer(**kwargs),
+    normalize=True
+)
+
+# train model on training data
+model.fit(C_train, X_train, Y_train)
+
+assert np.allclose(model.scaler_C.mean_, np.mean(C_train, axis=0), atol=1e-1), "C normalization failed!"
+assert np.allclose(model.scaler_C.scale_, np.std(C_train, axis=0), atol=1e-1), "C normalization failed!"
+assert np.allclose(model.scaler_X.mean_, np.mean(X_train, axis=0), atol=1e-1), "X normalization failed!"
+assert np.allclose(model.scaler_X.scale_, np.std(X_train, axis=0), atol=1e-1), "X normalization failed!"
+
+print("\n✅ fit() successfully normalized C_train and X_train!")
+
+# predict on test data by trained model
+Y_pred = model.predict(C_test, X_test)
+
+assert Y_pred is not None, "predict() failed!"
+assert Y_pred.shape == Y_test.shape, "predict() has wrong output shape!"
+
+print("\n✅ predict() ran successfully, un-normalized C_test and X_test were correctly treated!")
+print("predicted value:", Y_pred)

--- a/tests/test_plot_homo_con_effects.py
+++ b/tests/test_plot_homo_con_effects.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import numpy as np
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pandas as pd
+from contextualized.easy import ContextualizedRegressor
+from contextualized.analysis.effects import plot_homogeneous_context_effects
+
+
+def test_plot_homogeneous_context_effects():
+    
+    # make up some data
+    np.random.seed(42)
+    C = np.random.rand(100, 2)
+    X = np.random.rand(100, 3)
+    Y = X @ np.array([1.0, -0.5, 2.0]) + C[:, 0] + np.random.randn(100)
+    Y = Y.reshape(-1, 1)
+
+    C_df = pd.DataFrame(C, columns=["context_1", "context_2"])  # original C
+
+    # construct model and train
+    model = ContextualizedRegressor(normalize=True, max_epochs=3)
+    model.fit(C_df, X, Y)
+
+    # plot test for original C
+    print("🔍 Plotting with original (normalized internally) C...")
+    plot_homogeneous_context_effects(model, C_df, inverse_transform=True)
+
+    # # plot test for normalized C
+    # print("🔍 Plotting with manually scaled C and original_C override...")
+    # C_scaled = model.scaler_C.transform(C_df)
+    # plot_homogeneous_context_effects(model, C_scaled, inverse_transform=True, original_C=C_df) # C_df still needed for column names
+
+if __name__ == "__main__":
+    test_plot_homogeneous_context_effects()


### PR DESCRIPTION
- Added support for normalize=True in ContextualizedRegresso
- Normalized both C and X during fit() and predict()
- Included internal scalers to apply consistent transformation

TO DO:
- update SKLearnWrapper
- update docs