### PR TITLE
Throw warnings for incorrect args and kwargs

### DIFF
--- a/contextualized/analysis/embeddings.py
+++ b/contextualized/analysis/embeddings.py
@@ -9,6 +9,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 from matplotlib.lines import Line2D
+from contextualized.utils import check_kwargs
 
 
 def convert_to_one_hot(col: Collection[Any]) -> Tuple[np.ndarray, List[Any]]:
@@ -92,6 +93,13 @@ def plot_lowdim_rep(
     """
 
     plot_nan = kwargs.get("plot_nan", True)  # whether to plot NaN points
+    allowed_keys = [
+        "max_classes_for_discrete", "figsize", "alpha", "xlabel", "xlabel_fontsize",
+        "ylabel", "ylabel_fontsize", "title", "title_fontsize", "cbar_label",
+        "cbar_fontsize", "figname", "min_samples"
+    ]
+    check_kwargs(kwargs, allowed_keys)
+
     if len(set(labels)) < kwargs.get("max_classes_for_discrete", 10):  # discrete labels
         discrete = True
         cmap = plt.cm.jet

--- a/contextualized/analysis/embeddings.py
+++ b/contextualized/analysis/embeddings.py
@@ -92,14 +92,25 @@ def plot_lowdim_rep(
         None
     """
 
-    plot_nan = kwargs.get("plot_nan", True)  # whether to plot NaN points
     allowed_keys = [
-        "max_classes_for_discrete", "figsize", "alpha", "xlabel", "xlabel_fontsize",
-        "ylabel", "ylabel_fontsize", "title", "title_fontsize", "cbar_label",
-        "cbar_fontsize", "figname", "min_samples"
+        "max_classes_for_discrete",
+        "figsize",
+        "alpha",
+        "xlabel",
+        "xlabel_fontsize",
+        "ylabel",
+        "ylabel_fontsize",
+        "title",
+        "title_fontsize",
+        "cbar_label",
+        "cbar_fontsize",
+        "figname",
+        "min_samples",
+        "plot_nan",
     ]
     check_kwargs(kwargs, allowed_keys)
 
+    plot_nan = kwargs.get("plot_nan", True)  # whether to plot NaN points
     if len(set(labels)) < kwargs.get("max_classes_for_discrete", 10):  # discrete labels
         discrete = True
         cmap = plt.cm.jet

--- a/contextualized/analysis/tests.py
+++ b/contextualized/analysis/tests.py
@@ -194,12 +194,13 @@ class TestPlotLowdimRep(unittest.TestCase):
 
 class TestCheckKwargs(unittest.TestCase):
     def test_allowed_kwargs(self):
-        # 不应抛出异常
-        plot_lowdim_rep(np.random.randn(5,2), np.array([0,1,0,1,0]), alpha=0.5)
+        plot_lowdim_rep(
+            np.random.randn(5, 2), np.array([0, 1, 0, 1, 0]), alpha=0.5, plot_nan=False
+        )
 
     def test_unallowed_kwargs(self):
         with self.assertWarns(UserWarning):
-            plot_lowdim_rep(np.random.randn(5,2), np.array([0,1,0,1,0]), foo="bar")
+            plot_lowdim_rep(np.random.randn(5, 2), np.array([0, 1, 0, 1, 0]), foo="bar")
 
 
 if __name__ == "__main__":

--- a/contextualized/analysis/tests.py
+++ b/contextualized/analysis/tests.py
@@ -192,5 +192,15 @@ class TestPlotLowdimRep(unittest.TestCase):
         self.assertEqual(mock_scatter.call_count, 1)
 
 
+class TestCheckKwargs(unittest.TestCase):
+    def test_allowed_kwargs(self):
+        # 不应抛出异常
+        plot_lowdim_rep(np.random.randn(5,2), np.array([0,1,0,1,0]), alpha=0.5)
+
+    def test_unallowed_kwargs(self):
+        with self.assertWarns(UserWarning):
+            plot_lowdim_rep(np.random.randn(5,2), np.array([0,1,0,1,0]), foo="bar")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/contextualized/utils.py
+++ b/contextualized/utils.py
@@ -88,5 +88,5 @@ def check_kwargs(kwargs, allowed_keys, context=""):
             warnings.warn(
                 f"[{context}] Unexpected keyword argument: '{key}'",
                 category=UserWarning,
-                stacklevel=2
+                stacklevel=2,
             )

--- a/contextualized/utils.py
+++ b/contextualized/utils.py
@@ -3,6 +3,7 @@ Utility functions, including saving/loading of contextualized models.
 """
 
 import torch
+import warnings
 
 
 def save(model, path):
@@ -62,3 +63,30 @@ class DummyYPredictor:
         """
         n = len(args[0])
         return torch.zeros((n, *self.y_dim))
+
+
+def check_kwargs(kwargs, allowed_keys, context=""):
+    """
+    Check for unexpected keyword arguments and issue warnings.
+
+    Parameters
+    ----------
+    kwargs : dict
+        Dictionary of keyword arguments to validate.
+    allowed_keys : set or list
+        The expected valid keyword argument names.
+    context : str
+        Optional name of the function or class calling this check.
+
+    Raises
+    ------
+    UserWarning for any unknown key in kwargs.
+    """
+    allowed_keys = set(allowed_keys)
+    for key in kwargs:
+        if key not in allowed_keys:
+            warnings.warn(
+                f"[{context}] Unexpected keyword argument: '{key}'",
+                category=UserWarning,
+                stacklevel=2
+            )


### PR DESCRIPTION
### Summary
This PR adds a unified check_kwargs() function to contextualized/utils.py for validating keyword arguments (**kwargs) across modules.
Although the function is centralized, each function or class must individually call check_kwargs(...) with its own list of allowed arguments.

### Changes
Added check_kwargs() utility to utils.py, which: Accepts kwargs, a list/set of allowed keys, and a context string;
Emits a UserWarning if unexpected arguments are passed;
Applied check_kwargs() in one example function: plot_lowdim_rep() in embeddings.py.

### Next Steps
Apply check_kwargs() to other modules.

Related to #93