### PR TITLE
Robust bootstrap aggregation in predict to handle NaN/Inf (#249)

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -6,5 +6,6 @@ Thank you to everyone here for your impactful contributions!
 - Rich Caruana
 - Avinava Dubey
 - Manolis Kellis
+- Samuel Wales-McGrath
 - Eric Xing
 - Jason Miller

--- a/contextualized/easy/wrappers/SKLearnWrapper.py
+++ b/contextualized/easy/wrappers/SKLearnWrapper.py
@@ -413,7 +413,7 @@ class SKLearnWrapper:
 
     def _nanrobust_mean(self, arr, axis=0):
         """
-        arr : numpy array (may contain NaN/Inf)
+        arr : numpy array (possible NaN/Inf)
         axis : int, axis to average over (default=0)
         """
         
@@ -461,7 +461,9 @@ class SKLearnWrapper:
 
         if self.normalize and self.scalers["Y"] is not None:
             if individual_preds:
-                preds = np.array([self.scalers["Y"].inverse_transform(p) for p in preds])
+                preds = np.array(
+                    [self.scalers["Y"].inverse_transform(p) for p in preds]
+                    )
             else:
                 preds = self.scalers["Y"].inverse_transform(preds)
         return preds

--- a/contextualized/easy/wrappers/SKLearnWrapper.py
+++ b/contextualized/easy/wrappers/SKLearnWrapper.py
@@ -2,9 +2,6 @@
 An sklearn-like wrapper for Contextualized models.
 """
 
-"""
-sam rules
-"""
 import copy
 import os
 from typing import *

--- a/contextualized/easy/wrappers/SKLearnWrapper.py
+++ b/contextualized/easy/wrappers/SKLearnWrapper.py
@@ -2,6 +2,9 @@
 An sklearn-like wrapper for Contextualized models.
 """
 
+"""
+sam rules
+"""
 import copy
 import os
 from typing import *

--- a/contextualized/easy/wrappers/SKLearnWrapper.py
+++ b/contextualized/easy/wrappers/SKLearnWrapper.py
@@ -411,23 +411,28 @@ class SKLearnWrapper:
             return self.scalers["X"].transform(X)
         return X
 
-    def predict(
-        self, C: np.ndarray, X: np.ndarray, individual_preds: bool = False, **kwargs
-    ) -> Union[np.ndarray, List[np.ndarray]]:
-        """Predict outcomes from context C and predictors X.
-
-        Args:
-            C (np.ndarray): Context array of shape (n_samples, n_context_features)
-            X (np.ndarray): Predictor array of shape (N, n_features)
-            individual_preds (bool, optional): Whether to return individual predictions for each model. Defaults to False.
-
-        Returns:
-            Union[np.ndarray, List[np.ndarray]]: The outcomes predicted by the context-specific models (n_samples, y_dim). Returned as lists of individual bootstraps if individual_preds is True.
+    def _nanrobust_mean(self, arr, axis=0):
         """
-        if not hasattr(self, "models") or self.models is None:
-            raise ValueError(
-                "Trying to predict with a model that hasn't been trained yet."
+        arr : numpy array (may contain NaN/Inf)
+        axis : int, axis to average over (default=0)
+        """
+        
+        if not np.isfinite(arr).all():
+            # convert infs to nans so they can be dropped
+            arr = np.where(np.isfinite(arr), arr, np.nan)
+        with np.errstate(invalid="ignore"):
+            mean = np.nanmean(arr, axis=axis)
+        if np.isnan(mean).any():
+            # all bootstraps failed for an element
+            raise RuntimeError(
+                "All bootstraps produced non-finite predictions for some items. "
             )
+        return mean
+    
+    
+    def predict(self, C: np.ndarray, X: np.ndarray, individual_preds: bool = False, **kwargs):
+        if not hasattr(self, "models") or self.models is None:
+            raise ValueError("Trying to predict with a model that hasn't been trained yet.")
         predictions = np.array(
             [
                 self.trainers[i].predict_y(
@@ -440,20 +445,28 @@ class SKLearnWrapper:
                     **kwargs,
                 )
                 for i in range(len(self.models))
-            ]
+            ],
+            dtype=float,
         )
+        # aggregation across bootstraps
         if individual_preds:
             preds = predictions
         else:
-            preds = np.mean(predictions, axis=0)
+            # warn if any bootstrap produced non finite values
+            bad = ~np.isfinite(predictions)
+            if bad.any():
+                num_bad_boots = np.unique(np.where(bad)[0]).size
+                print(f"Warning: {num_bad_boots}/{len(self.models)} bootstraps produced non-finite predictions; excluding them from the ensemble.")
+            preds = self._nanrobust_mean(predictions, axis=0)
+
         if self.normalize and self.scalers["Y"] is not None:
             if individual_preds:
-                preds = np.array(
-                    [self.scalers["Y"].inverse_transform(p) for p in preds]
-                )
+                preds = np.array([self.scalers["Y"].inverse_transform(p) for p in preds])
             else:
                 preds = self.scalers["Y"].inverse_transform(preds)
         return preds
+    
+    
 
     def predict_params(
         self,


### PR DESCRIPTION
Fixes issue #249 by making bootstrap aggregation in predict nan-robust. Previously, a single NaN/Inf from one bootstrap would poison the entire ensemble mean, causing outlier tolerance to shrink as n_bootstraps increased. Now, Inf is converted to NaN, np.nanmean is used to ignore bad outputs, and a clear error is raised if all bootstraps fail. Warnings report excluded bootstraps, and dtype=float ensures consistency. This keeps results stable across machines and bootstrap counts while preserving the existing interface.